### PR TITLE
Add tmux wrapper for pycat + rlwrap

### DIFF
--- a/start_client.sh
+++ b/start_client.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-LD_PRELOAD=libboost_serialization.so:libboost_python37.so:libpython3.7m.so::libstdc++.so.6:libmapper.so rlwrap ./pycat.py "${MODULE:-client}" "${ARG}"
+LD_PRELOAD=libboost_serialization.so:libboost_python37.so:libpython3.7m.so::libstdc++.so.6:libmapper.so ./pycat.py "${MODULE:-coffee}" "${ARG}"

--- a/tmux.sh
+++ b/tmux.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+fifo="/tmp/pycat-rlwrap-fifo"
+if [ ! -f $fifo ]; then
+	mkfifo $fifo
+fi
+
+tmux new-session \; \
+  send-keys "./start_client.sh < $fifo" C-m \; \
+  split-window -v -p 1 \; \
+  send-keys "rlwrap tee $fifo" C-m \;


### PR DESCRIPTION
Fixes issue #3.

It's important to exit from tmux when terminal is closed, otherwise it stays in background and messes up subsequent invocations (two copies use same FIFO).