### PR TITLE
Graceful exit

### DIFF
--- a/modules/repeat.py
+++ b/modules/repeat.py
@@ -10,5 +10,7 @@ class Repeat(BaseModule):
     def alias(self, line):
         if line == '':
             self.mud.send(self.outlog[0])
+        elif line == '#nl':
+            self.mud.send('')
         else:
             self.outlog.appendleft(line)

--- a/modules/repeat.py
+++ b/modules/repeat.py
@@ -9,13 +9,6 @@ class Repeat(BaseModule):
 
     def alias(self, line):
         if line == '':
-            if len(self.outlog) > 0:
-                self.mud.send(self.outlog[0])
-            # Signal to the client that the alias has consumed the input line
-            return True
-        elif line == '#nl':
-            self.mud.send('')
-            return True  # Consume input line
+            self.mud.send(self.outlog[0])
         else:
             self.outlog.appendleft(line)
-

--- a/modules/repeat.py
+++ b/modules/repeat.py
@@ -9,8 +9,13 @@ class Repeat(BaseModule):
 
     def alias(self, line):
         if line == '':
-            self.mud.send(self.outlog[0])
+            if len(self.outlog) > 0:
+                self.mud.send(self.outlog[0])
+            # Signal to the client that the alias has consumed the input line
+            return True
         elif line == '#nl':
             self.mud.send('')
+            return True  # Consume input line
         else:
             self.outlog.appendleft(line)
+

--- a/pycat.py
+++ b/pycat.py
@@ -236,6 +236,7 @@ def main():
     try:
         ses.run()
     except KeyboardInterrupt:
+        print('\nConnection Terminated. Awaiting interrupt to exit program.')
         exit(0)  # Exit on C^c
 
 

--- a/pycat.py
+++ b/pycat.py
@@ -231,7 +231,10 @@ def main():
     port = int(sys.argv[2])
     arg = sys.argv[3] if len(sys.argv) == 4 else None
     ses = Session(world_module, port, arg)
-    ses.run()
+    try:
+        ses.run()
+    except KeyboardInterrupt:
+        pass
 
 
 assert(__name__ == '__main__')

--- a/pycat.py
+++ b/pycat.py
@@ -212,8 +212,11 @@ class Session(object):
                         self.handle_from_telnet()
                     elif fd == self.socketToPipeR:
                         self.handle_from_pipe()
-        except Exception as e:
-            traceback.print_exc()
+        except Exception as error:
+            if type(error) is EOFError:
+                pass  # This simply means the telnet connection was closed.
+            else:
+                traceback.print_exc()
         finally:
             self.log("Closing")
             self.telnet.close()

--- a/pycat.py
+++ b/pycat.py
@@ -212,9 +212,11 @@ class Session(object):
                         self.handle_from_telnet()
                     elif fd == self.socketToPipeR:
                         self.handle_from_pipe()
-        except Exception as error:
+        except (Exception, KeyboardInterrupt) as error:
             if type(error) is EOFError:
                 pass  # This simply means the telnet connection was closed.
+            elif type(error) is KeyboardInterrupt:
+                raise  # pass the user's C^c up to main()
             else:
                 traceback.print_exc()
         finally:
@@ -234,7 +236,7 @@ def main():
     try:
         ses.run()
     except KeyboardInterrupt:
-        raise
+        exit(0)  # Exit on C^c
 
 
 assert(__name__ == '__main__')

--- a/pycat.py
+++ b/pycat.py
@@ -234,7 +234,7 @@ def main():
     try:
         ses.run()
     except KeyboardInterrupt:
-        pass
+        raise
 
 
 assert(__name__ == '__main__')


### PR DESCRIPTION
Exceptions are caused when the mud closes the connection and when the user sends a keyboard interrupt.
- This fixes the exception when the mud closes
- This fixes one of the three exceptions on interrupt and chains it up.  Now it only takes two interrupts to exit (with two exceptions still firing)